### PR TITLE
.travis.yml: prefer `cover -test` over setting PERL5OPT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ perl:
     - "5.16"
     - "5.14"
 script:
-    - perl Build.PL && ./Build build && PERL5OPT=-MDevel::Cover ./Build test
+    - perl Build.PL && ./Build build && cover -test
 after_success:
     - cover -report codecov


### PR DESCRIPTION
Using `PERL5OPT` can lead to unintentional failures when forking (especially across different Perl versions in corner cases.)  Use the standard `cover -test` command instead, which is already provided by Devel::Cover.